### PR TITLE
Add swap program recognition and blockhash refresh

### DIFF
--- a/solanakit/src/main/java/io/horizontalsystems/solanakit/SolanaKit.kt
+++ b/solanakit/src/main/java/io/horizontalsystems/solanakit/SolanaKit.kt
@@ -28,7 +28,9 @@ import io.horizontalsystems.solanakit.network.ConnectionManager
 import io.horizontalsystems.solanakit.noderpc.ApiSyncer
 import io.horizontalsystems.solanakit.noderpc.NftClient
 import io.horizontalsystems.solanakit.transactions.JupiterApiService
+import io.horizontalsystems.solanakit.transactions.KnownPrograms
 import io.horizontalsystems.solanakit.transactions.PendingTransactionSyncer
+import io.horizontalsystems.solanakit.transactions.RawTransactionParser
 import io.horizontalsystems.solanakit.transactions.TransactionManager
 import io.horizontalsystems.solanakit.transactions.TransactionSyncer
 import kotlinx.coroutines.CoroutineScope
@@ -46,6 +48,7 @@ import org.sol4k.Base58
 import org.sol4k.Connection
 import org.sol4k.RpcUrl
 import org.sol4k.VersionedTransaction
+import org.sol4k.api.Blockhash
 import org.sol4k.api.Commitment
 import java.math.BigDecimal
 import java.time.Instant
@@ -213,16 +216,37 @@ class SolanaKit(
     }
 
     fun sendRawTransaction(hexEncoded: ByteArray, signer: Signer): FullTransaction {
+        val parsed = RawTransactionParser.parse(hexEncoded)
         val base64Encoded = Base64.getEncoder().encodeToString(hexEncoded)
-        val versionedTx = VersionedTransaction.from(base64Encoded)
+        var versionedTx = VersionedTransaction.from(base64Encoded)
+
+        val connection = Connection(RpcUrl.MAINNNET)
+
+        // Refresh the recent blockhash just before signing. Externally-built transactions
+        // (e.g. server-assembled Jupiter swaps) routinely outlive their embedded blockhash
+        // (~60-90s) while the user reviews a confirmation screen — broadcasting then fails
+        // with "Blockhash not found". Replacing it is only safe while nobody else has signed
+        // (a co-signature covers the old bytes), so it is limited to single-signer
+        // transactions. The response is reused below for `lastValidBlockHeight`, which then
+        // describes the blockhash actually embedded in the broadcast transaction; on the
+        // co-signed path it is fetched separately, as before — an UPPER BOUND for the older
+        // embedded blockhash, so pending-expiry detection can lag but never fires early.
+        var refreshedBlockhash: Blockhash? = null
+        if (parsed.requiredSignatures <= 1) {
+            refreshedBlockhash = connection.getLatestBlockhashExtended(Commitment.FINALIZED)
+            versionedTx = VersionedTransaction(versionedTx.message.withNewBlockhash(refreshedBlockhash.blockhash))
+        }
+
         val signature = Base58.encode(signer.account.sign(versionedTx.message.serialize()))
         versionedTx.addSignature(signature)
         val base64WithSignature = Base64.getEncoder().encodeToString(versionedTx.serialize())
 
-        val connection = Connection(RpcUrl.MAINNNET)
-        val blockHash = connection.getLatestBlockhashExtended(Commitment.FINALIZED)
-
         val transactionHash = connection.sendTransaction(versionedTx)
+
+        // Reused from the pre-signing refresh when the message was rewritten; fetched only now,
+        // post-broadcast, on the co-signed path — a transient RPC failure must not abort a send
+        // whose embedded blockhash is still valid.
+        val blockhashInfo = refreshedBlockhash ?: connection.getLatestBlockhashExtended(Commitment.FINALIZED)
 
         val fullTransaction = FullTransaction(
             transaction = Transaction(
@@ -233,11 +257,21 @@ class SolanaKit(
                 to = null,
                 amount = null,
                 pending = true,
-                lastValidBlockHeight = blockHash.lastValidBlockHeight,
-                base64Encoded = base64WithSignature
+                blockHash = refreshedBlockhash?.blockhash ?: parsed.recentBlockhash,
+                lastValidBlockHeight = blockhashInfo.lastValidBlockHeight,
+                base64Encoded = base64WithSignature,
+                // The program invoked by each compiled instruction (program ids are always
+                // static account keys), filtered to the recognized set — lets clients render
+                // e.g. a Jupiter interaction as a swap while it is still pending. Same
+                // instruction-based derivation as TransactionSyncer's.
+                programIds = KnownPrograms.recognized(parsed.invokedProgramIds)
             ),
             listOf()
         )
+
+        // Persist and emit (as sendSol/sendSpl do), so the pending record shows up in history
+        // immediately instead of only after the next sync discovers it on-chain.
+        transactionManager.registerPendingTransaction(fullTransaction)
 
         return fullTransaction
     }

--- a/solanakit/src/main/java/io/horizontalsystems/solanakit/database/transaction/TransactionDatabase.kt
+++ b/solanakit/src/main/java/io/horizontalsystems/solanakit/database/transaction/TransactionDatabase.kt
@@ -5,6 +5,8 @@ import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import io.horizontalsystems.solanakit.database.transaction.dao.MintAccountDao
 import io.horizontalsystems.solanakit.database.transaction.dao.TokenAccountDao
 import io.horizontalsystems.solanakit.database.transaction.dao.TransactionSyncerStateDao
@@ -19,7 +21,7 @@ import io.horizontalsystems.solanakit.models.*
         Transaction::class,
         TokenAccount::class
     ],
-    version = 8,
+    version = 9,
     exportSchema = false
 )
 @TypeConverters(RoomTypeConverters::class)
@@ -32,11 +34,18 @@ abstract class TransactionDatabase : RoomDatabase() {
 
     companion object {
 
+        private val MIGRATION_8_9 = object : Migration(8, 9) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `Transaction` ADD COLUMN `programIds` TEXT")
+            }
+        }
+
         fun getInstance(context: Context, databaseName: String): TransactionDatabase {
             return Room.databaseBuilder(context, TransactionDatabase::class.java, databaseName)
 //                .setQueryCallback({ sqlQuery, bindArgs ->
 //                    println("SQL Query: $sqlQuery SQL Args: $bindArgs")
 //                }, Executors.newSingleThreadExecutor())
+                .addMigrations(MIGRATION_8_9)
                 .fallbackToDestructiveMigration()
                 .allowMainThreadQueries()
                 .build()

--- a/solanakit/src/main/java/io/horizontalsystems/solanakit/database/transaction/TransactionStorage.kt
+++ b/solanakit/src/main/java/io/horizontalsystems/solanakit/database/transaction/TransactionStorage.kt
@@ -26,14 +26,38 @@ class TransactionStorage(
         transactionsDao.pendingTransactions()
 
     fun updateTransactions(transactions: List<Transaction>) =
-        transactionsDao.updateTransactions(transactions)
+        transactionsDao.updateTransactions(backfillProgramIds(transactions))
 
     fun addTransactions(transactions: List<FullTransaction>) {
-        transactionsDao.insertTransactions(transactions.map { it.transaction })
+        transactionsDao.insertTransactions(backfillProgramIds(transactions.map { it.transaction }))
 
         val fullTokenTransfers = transactions.map { it.tokenTransfers }.flatten()
         transactionsDao.insertTokenTransfers(fullTokenTransfers.map { it.tokenTransfer })
         mintAccountDao.insert(fullTokenTransfers.map { it.mintAccount }.toSet().toList())
+    }
+
+    // Both write paths perform full-row rewrites (REPLACE on insert, all-columns UPDATE on
+    // update), so a writer that doesn't carry `programIds` would silently null an existing tag
+    // and un-label a classified swap. The tag is immutable once known — a transaction's invoked
+    // programs never change — so backfill it from the stored rows whenever incoming ones lack
+    // it. One batched SELECT over the missing hashes (restricted to rows that HAVE a tag), not
+    // a per-row lookup: history syncs funnel the whole batch through a single write.
+    private fun backfillProgramIds(transactions: List<Transaction>): List<Transaction> {
+        val missingHashes = transactions.mapNotNull { if (it.programIds == null) it.hash else null }
+        if (missingHashes.isEmpty()) return transactions
+
+        val stored = missingHashes.chunked(500)
+            .flatMap { transactionsDao.getProgramIds(it) }
+            .associate { it.hash to it.programIds }
+        if (stored.isEmpty()) return transactions
+
+        return transactions.map { transaction ->
+            if (transaction.programIds == null) {
+                stored[transaction.hash]?.let { transaction.copy(programIds = it) } ?: transaction
+            } else {
+                transaction
+            }
+        }
     }
 
     suspend fun getTransactions(incoming: Boolean?, fromHash: String?, limit: Int?): List<FullTransaction> {

--- a/solanakit/src/main/java/io/horizontalsystems/solanakit/database/transaction/dao/TransactionsDao.kt
+++ b/solanakit/src/main/java/io/horizontalsystems/solanakit/database/transaction/dao/TransactionsDao.kt
@@ -17,6 +17,14 @@ interface TransactionsDao {
     @Query("SELECT * FROM `Transaction` WHERE pending ORDER BY timestamp")
     fun pendingTransactions() : List<Transaction>
 
+    @Query("SELECT hash, programIds FROM `Transaction` WHERE hash IN (:hashes) AND programIds IS NOT NULL")
+    fun getProgramIds(hashes: List<String>): List<HashWithProgramIds>
+
+    data class HashWithProgramIds(
+        val hash: String,
+        val programIds: String
+    )
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertTransactions(transactions: List<Transaction>)
 

--- a/solanakit/src/main/java/io/horizontalsystems/solanakit/models/Transaction.kt
+++ b/solanakit/src/main/java/io/horizontalsystems/solanakit/models/Transaction.kt
@@ -18,5 +18,9 @@ data class Transaction(
     val blockHash: String = "",
     val lastValidBlockHeight: Long = 0,
     val base64Encoded: String = "",
-    val retryCount: Int = 0
+    val retryCount: Int = 0,
+    // Space-separated RECOGNIZED program ids this transaction invoked (see KnownPrograms), e.g.
+    // the Jupiter aggregator — lets clients classify swaps ("Swapped via Jupiter") instead of
+    // rendering an unknown multi-transfer transaction. Null when none were recognized.
+    val programIds: String? = null
 )

--- a/solanakit/src/main/java/io/horizontalsystems/solanakit/transactions/KnownPrograms.kt
+++ b/solanakit/src/main/java/io/horizontalsystems/solanakit/transactions/KnownPrograms.kt
@@ -1,0 +1,30 @@
+package io.horizontalsystems.solanakit.transactions
+
+/**
+ * Program ids the kit RECOGNIZES and surfaces on `Transaction.programIds`, so clients can
+ * classify transactions (e.g. render a Jupiter interaction as a swap instead of an unknown
+ * multi-transfer). Deliberately a small allowlist — and callers must pass INVOKED program ids
+ * (from the transaction's instructions), never raw `accountKeys`: account keys mix programs
+ * with ordinary accounts, so presence there does not mean the program ran (a wallet merely
+ * RECEIVING the tail of someone else's swap would be mislabeled).
+ *
+ * Extend by appending — the stored value is just the id string, so older rows stay valid.
+ */
+object KnownPrograms {
+    /** Jupiter aggregator v6. */
+    const val jupiterV6 = "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4"
+
+    /** All recognized program ids. */
+    val all: Set<String> = setOf(jupiterV6)
+
+    /**
+     * The recognized subset of [candidates], deduplicated (first occurrence wins, order
+     * preserved) and space-joined for `Transaction.programIds`; null when none are recognized.
+     * Deduplication matters because callers pass one candidate per INSTRUCTION — a program
+     * invoked twice in one transaction must still yield a single entry.
+     */
+    internal fun recognized(candidates: List<String>): String? {
+        val hits = candidates.filter { it in all }.distinct()
+        return if (hits.isEmpty()) null else hits.joinToString(" ")
+    }
+}

--- a/solanakit/src/main/java/io/horizontalsystems/solanakit/transactions/RawTransactionParser.kt
+++ b/solanakit/src/main/java/io/horizontalsystems/solanakit/transactions/RawTransactionParser.kt
@@ -1,0 +1,78 @@
+package io.horizontalsystems.solanakit.transactions
+
+import org.sol4k.Base58
+
+/**
+ * Minimal reader of a serialized Solana transaction (legacy or V0), extracting only what
+ * `SolanaKit.sendRawTransaction` needs and sol4k does not expose publicly (its
+ * `TransactionMessage.accounts`/`instructions` are internal): the signature count, the embedded
+ * blockhash, and the program id INVOKED by each top-level instruction. Program ids are always
+ * static account keys (the runtime forbids loading programs from lookup tables), so V0 lookup
+ * tables — everything after the instruction list — never need to be parsed.
+ */
+internal object RawTransactionParser {
+
+    data class ParsedTransaction(
+        val signatureCount: Int,
+        val requiredSignatures: Int,
+        /** Base58 blockhash embedded in the message. */
+        val recentBlockhash: String,
+        /** Base58 program id invoked by each top-level instruction, in order. */
+        val invokedProgramIds: List<String>,
+    )
+
+    fun parse(rawTransaction: ByteArray): ParsedTransaction {
+        var offset = 0
+
+        fun readByte(): Int = rawTransaction[offset++].toInt() and 0xFF
+
+        // compact-u16 ("shortvec"): 7 bits per byte, high bit = continuation
+        fun readLength(): Int {
+            var length = 0
+            var shift = 0
+            while (true) {
+                val byte = readByte()
+                length = length or ((byte and 0x7F) shl shift)
+                if (byte and 0x80 == 0) return length
+                shift += 7
+            }
+        }
+
+        val signatureCount = readLength()
+        offset += signatureCount * 64
+
+        // V0 messages are marked by the high bit of the first message byte; legacy has none.
+        if (rawTransaction[offset].toInt() and 0x80 != 0) {
+            offset++
+        }
+
+        val requiredSignatures = readByte()
+        offset += 2 // numReadonlySignedAccounts, numReadonlyUnsignedAccounts
+
+        val accountCount = readLength()
+        val accountKeys = List(accountCount) {
+            val key = rawTransaction.copyOfRange(offset, offset + 32)
+            offset += 32
+            key
+        }
+
+        val recentBlockhash = Base58.encode(rawTransaction.copyOfRange(offset, offset + 32))
+        offset += 32
+
+        val instructionCount = readLength()
+        val invokedProgramIds = mutableListOf<String>()
+        repeat(instructionCount) {
+            val programIdIndex = readByte()
+            val instructionAccountCount = readLength()
+            offset += instructionAccountCount
+            val dataLength = readLength()
+            offset += dataLength
+
+            accountKeys.getOrNull(programIdIndex)?.let {
+                invokedProgramIds.add(Base58.encode(it))
+            }
+        }
+
+        return ParsedTransaction(signatureCount, requiredSignatures, recentBlockhash, invokedProgramIds)
+    }
+}

--- a/solanakit/src/main/java/io/horizontalsystems/solanakit/transactions/TransactionManager.kt
+++ b/solanakit/src/main/java/io/horizontalsystems/solanakit/transactions/TransactionManager.kt
@@ -85,16 +85,27 @@ class TransactionManager(
                     val existingTxHeader = existingTx.transaction
 
                     FullTransaction(
-                        transaction = Transaction(
-                            hash = syncedTxHeader.hash,
-                            timestamp = syncedTxHeader.timestamp,
+                        // Merge by COPYING the stored record: columns not named here (blockHash,
+                        // lastValidBlockHeight, base64Encoded, retryCount, and any future ones)
+                        // keep their stored values automatically, so a column can't be silently
+                        // reset to its default by an incomplete constructor call.
+                        transaction = existingTxHeader.copy(
+                            // Keep the stored timestamp when the confirmed record reports none
+                            // (blockTime can be null on a just-confirmed tx) — the pending row's
+                            // send-time value beats overwriting it with 0, which would jump the
+                            // row to 1970.
+                            timestamp = if (syncedTxHeader.timestamp != 0L) syncedTxHeader.timestamp else existingTxHeader.timestamp,
                             fee = syncedTxHeader.fee,
                             from = syncedTxHeader.from ?: existingTxHeader.from,
                             to = syncedTxHeader.to ?: existingTxHeader.to,
                             amount = syncedTxHeader.amount ?: existingTxHeader.amount,
                             error = syncedTxHeader.error,
                             pending = syncedTxHeader.pending,
-                            ),
+                            // Freshly derived tag wins (the stored one may predate the program
+                            // joining KnownPrograms); fall back to the stored value when the
+                            // sync derived none.
+                            programIds = syncedTxHeader.programIds ?: existingTxHeader.programIds,
+                        ),
                         tokenTransfers = syncedTx.tokenTransfers.ifEmpty {
                             for (tokenTransfer in existingTx.tokenTransfers) {
                                 existingMintAddresses.add(tokenTransfer.mintAccount.address)
@@ -117,6 +128,13 @@ class TransactionManager(
 
     fun notifyTransactionsUpdate(transactions: List<FullTransaction>) {
         _transactionsFlow.tryEmit(transactions)
+    }
+
+    // Persists and emits a just-broadcast transaction (same as the sendSol/sendSpl tail), so an
+    // externally-built raw send (e.g. a Jupiter swap) appears in history immediately as pending.
+    fun registerPendingTransaction(fullTransaction: FullTransaction) {
+        storage.addTransactions(listOf(fullTransaction))
+        _transactionsFlow.tryEmit(listOf(fullTransaction))
     }
 
     private fun hasSolTransfer(fullTransaction: FullTransaction, incoming: Boolean?): Boolean {

--- a/solanakit/src/main/java/io/horizontalsystems/solanakit/transactions/TransactionModels.kt
+++ b/solanakit/src/main/java/io/horizontalsystems/solanakit/transactions/TransactionModels.kt
@@ -42,7 +42,16 @@ data class TransactionDetail(
 
 @JsonClass(generateAdapter = true)
 data class TransactionMessage(
-    val accountKeys: List<AccountKey>?
+    val accountKeys: List<AccountKey>?,
+    val instructions: List<InstructionInfo>?
+)
+
+// A top-level instruction in a transaction message (jsonParsed format). Both jsonParsed
+// shapes (`parsed` and `partiallyDecoded`) carry the invoked `programId` directly; the
+// remaining fields differ per shape and are not needed here, so only `programId` is decoded.
+@JsonClass(generateAdapter = true)
+data class InstructionInfo(
+    val programId: String?
 )
 
 @JsonClass(generateAdapter = true)

--- a/solanakit/src/main/java/io/horizontalsystems/solanakit/transactions/TransactionSyncer.kt
+++ b/solanakit/src/main/java/io/horizontalsystems/solanakit/transactions/TransactionSyncer.kt
@@ -338,7 +338,15 @@ class TransactionSyncer(
             to = solTo,
             amount = solAmount,
             error = error,
-            pending = false
+            pending = false,
+            // Derive from the INVOKED program of each top-level instruction (jsonParsed carries
+            // `programId` per instruction) — never from accountKeys presence, which would also
+            // match transactions that merely reference a program (e.g. the wallet receiving the
+            // tail of someone else's Jupiter swap) and, with jsonParsed, lookup-table-loaded
+            // addresses. Matches the send-path derivation in SolanaKit.sendRawTransaction.
+            programIds = KnownPrograms.recognized(
+                response.transaction?.message?.instructions?.mapNotNull { it.programId } ?: emptyList()
+            )
         )
 
         return ParsedTransaction(

--- a/solanakit/src/test/java/io/horizontalsystems/solanakit/transactions/RawTransactionParserTest.kt
+++ b/solanakit/src/test/java/io/horizontalsystems/solanakit/transactions/RawTransactionParserTest.kt
@@ -1,0 +1,59 @@
+package io.horizontalsystems.solanakit.transactions
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.util.Base64
+
+class RawTransactionParserTest {
+
+    // Mainnet Jupiter v6 swap, V0 message (with address lookup tables):
+    // Yvc2AmmmMwn6FdTC3dFqDycTRFQgH7k7DDsQJ86UBtCqDCkb6aYCPnFQNJxY73v8gG7NncN36QGbRRHfFRiYY8t
+    private val jupiterV0Tx =
+        "ARuHvJNIL3Hufj/Jc0F2YK0kr/cY4/SfKn/QkYoKKuyi4L08LKUI0YwiECaCjgw2Y/2e5gC+Y0eEPcyqufPsyQ2AAQAECPSSlhqepX6/HrSS46MZovr/QNtZ9HF2x2ttHRJ0cznBM3emP5VTGuvhVAtCeCFtGVgsDuHOMh6LF14zatClMW1jPVMTQqan3xZwEdYvX58aLu6Xdy1fU3GBOPaSqvHHUMtqa1FW+FdtqQgM7bdPDCFOZ5j9Uk7MU5Q5jdUawfWwAwZGb+UhFzL/7K26csOb57yM5bvF9xJrLEObOkAAAAAEedVb8jHAbu50xW7OaBUH/bGy3qP0jlECsc2iVrwTj7Q/+if11/ZKdMCbHylYed5LCas238ndUUsyGqezjOXo+b7SB/D/xQH0I0yKJWMQqWtTyG+Uc19GnNIpb6dTvEe6rZDrB3d48x0OqLR+nR+Huz2kG440vpEuYzUGISDF0wMEAAUCxB4BAAQACQP/yBQAAAAAAAUYAAIBDw0MDAUGBQMOAAgKCQECDAwLEAUHKLtk+swxxK8UV3q0AwAAAAAl6jUAAAAAAGQAZAAAAAEAAACNABAnAAEBrt8BFUgV9dJh9BWPGETzkUh+QxeZ4SQ+ttVPXt2PgJEDVldPBlADU1IJVA=="
+
+    // Mainnet vote transaction, legacy message:
+    // 5BJHwpVVUe7QvEWPqd9sRYBfDAmcnQktZuxxF2wUL8EfqqioiC89tuDfx9g6QViChwKskcKq4yrdiHZEAXxAEyEz
+    private val voteLegacyTx =
+        "AdDy30G1yg1+wTQIzNT0Dc5BbabZcAh0iYIatn6wB7okOFhPl3RTzvucRkW39NOs8wc5vKHNyYoEbE8wqQpnIQMBAAEDFh1Q5EoE6hsz33ShzoO6H2XMw0J1VOpVk5rnVJovlWDIQWnKylvMxQTQuqMaTCl13d9yJOiySGGnglI/oM1gggdhSB01dHS7fE12JOvTvbPYNV5z0RBD/A2jU4AAAAAAX9ykmCtU6gUDFJwgP5MQnXvBR7/OLSfGoIZ1laswmL4BAgIBAJQBDgAAAP2hvBkAAAAAHwEfAR4BHQEcARsBGgEZARgBFwEWARUBFAETARIBEQEQAQ8BDgENAQwBCwEKAQkBCAEHAQYBBQEEAQMBAgEBzjhxYNQYHviIUm8mIjBQvEUvtsseDh42M41x1niNW/YBmYdPagAAAADm1RH7hxTjZLqQcKxeFQSa9YEfYj1poVOirkPjzkO2Yg=="
+
+    @Test
+    fun parseV0JupiterSwap() {
+        val parsed = RawTransactionParser.parse(Base64.getDecoder().decode(jupiterV0Tx))
+
+        assertEquals(1, parsed.signatureCount)
+        assertEquals(1, parsed.requiredSignatures)
+        assertEquals("DZiLQHwp8FzMvFicUXgVziiT6JHinNR1D3Mvn72tgnaW", parsed.recentBlockhash)
+        assertEquals(
+            listOf(
+                "ComputeBudget111111111111111111111111111111",
+                "ComputeBudget111111111111111111111111111111",
+                "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4",
+            ),
+            parsed.invokedProgramIds
+        )
+        assertEquals(KnownPrograms.jupiterV6, KnownPrograms.recognized(parsed.invokedProgramIds))
+    }
+
+    @Test
+    fun parseLegacyVoteTransaction() {
+        val parsed = RawTransactionParser.parse(Base64.getDecoder().decode(voteLegacyTx))
+
+        assertEquals(1, parsed.signatureCount)
+        assertEquals(1, parsed.requiredSignatures)
+        assertEquals("7TCsQQoyf35PhjhPHFbeAyYB2Noznn5YGJr3KvwVdR9o", parsed.recentBlockhash)
+        assertEquals(listOf("Vote111111111111111111111111111111111111111"), parsed.invokedProgramIds)
+        assertNull(KnownPrograms.recognized(parsed.invokedProgramIds))
+    }
+
+    @Test
+    fun recognizedDeduplicatesAndIgnoresUnknown() {
+        assertEquals(
+            KnownPrograms.jupiterV6,
+            KnownPrograms.recognized(
+                listOf("ComputeBudget111111111111111111111111111111", KnownPrograms.jupiterV6, KnownPrograms.jupiterV6)
+            )
+        )
+        assertNull(KnownPrograms.recognized(emptyList()))
+    }
+}


### PR DESCRIPTION
https://github.com/horizontalsystems/unstoppable-wallet-android/issues/9363

Enables clients to classify DEX swaps in transaction history:

- Transaction.programIds: recognized program ids (KnownPrograms allowlist, currently Jupiter v6) invoked by a transaction, persisted via a new column + Room migration. Derived from instructions (never accountKeys presence) at history sync and at send time, so a Jupiter swap can render as a swap already while pending.
- sendRawTransaction: refresh recentBlockhash just before signing (single-signer only) — externally-built transactions outlive their embedded blockhash (~60-90s) and failed with "Blockhash not found". Also persist + emit the pending record, as sendSol/sendSpl do.
- Preserve columns across row rewrites: handle() merges by copying the stored row (blockHash/lastValidBlockHeight/base64Encoded/retryCount were silently reset to defaults), and storage backfills programIds on both full-row write paths.
- RawTransactionParser reads signature count, blockhash and invoked program ids from raw tx bytes (sol4k keeps message internals internal); tested against real mainnet V0 and legacy fixtures.